### PR TITLE
シフト提出した画面に確定したシフト情報を入れる

### DIFF
--- a/client/src/pages/calendar/ShiftBoard.module.css
+++ b/client/src/pages/calendar/ShiftBoard.module.css
@@ -106,6 +106,10 @@
   ); /* この色はCornflowerBlueの透明度を60%にしたものです */
 }
 
+.fixedShiftDay {
+  background-color: rgba(0, 128, 0, 0.6);
+}
+
 .sunday {
   color: red; /* 日曜日の色 */
 }

--- a/server/api/shift3/controller.ts
+++ b/server/api/shift3/controller.ts
@@ -1,5 +1,10 @@
+import { getFixedShiftOnlyId } from '$/repository/shiftRepository';
 import { defineController } from './$relay';
 
 export default defineController(() => ({
   get: () => ({ status: 200, body: 'Hello' }),
+  post: async ({ body }) => ({
+    status: 201,
+    body: await getFixedShiftOnlyId(body.id),
+  }),
 }));

--- a/server/api/shift3/index.ts
+++ b/server/api/shift3/index.ts
@@ -1,7 +1,14 @@
 import type { DefineMethods } from 'aspida';
+import type { ShiftModel } from '../../commonTypesWithClient/models';
 
 export type Methods = DefineMethods<{
   get: {
     resBody: string;
+  };
+  post: {
+    reqBody: {
+      id: string;
+    };
+    resBody: ShiftModel[];
   };
 }>;

--- a/server/prisma/migrations/20230823180543_/migration.sql
+++ b/server/prisma/migrations/20230823180543_/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the `FixedShift` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "FixedShift";
+
+-- CreateTable
+CREATE TABLE "Fixedshift" (
+    "id" TEXT NOT NULL,
+    "date" TEXT NOT NULL,
+    "starttime" TEXT NOT NULL,
+    "endtime" TEXT NOT NULL,
+
+    CONSTRAINT "Fixedshift_pkey" PRIMARY KEY ("id","date")
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Shift {
   @@id([id, date])
 }
 
-model FixedShift {
+model Fixedshift {
   id        String
   date      String
   starttime String

--- a/server/repository/shiftRepository.ts
+++ b/server/repository/shiftRepository.ts
@@ -68,7 +68,7 @@ export const shiftRepository2 = {
     console.log(`Date: ${date}`);
     console.log(`Start Time: ${starttime}`);
     console.log(`End Time: ${endtime}`);
-    const res = await prismaClient.fixedShift.upsert({
+    const res = await prismaClient.fixedshift.upsert({
       where: { id_date: { id, date } },
       create: {
         id,
@@ -100,6 +100,20 @@ export const getShift = async (myId: string): Promise<ShiftModel[]> => {
   return prismaTasks.map(toShiftModel);
 };
 
+export const getFixedShiftOnlyId = async (myId: string): Promise<ShiftModel[]> => {
+  const prismaTasks = await prismaClient.shift.findMany({
+    where: { id: myId },
+    select: {
+      id: true,
+      date: true,
+      starttime: true,
+      endtime: true,
+    },
+  });
+
+  return prismaTasks.map(toShiftModel);
+};
+
 export const getSubmitShift = async (): Promise<ShiftModel[]> => {
   const prismaTasks = await prismaClient.shift.findMany({
     select: {
@@ -114,7 +128,7 @@ export const getSubmitShift = async (): Promise<ShiftModel[]> => {
 };
 
 export const getFixedShift = async (): Promise<ShiftModel[]> => {
-  const prismaTasks = await prismaClient.fixedShift.findMany({
+  const prismaTasks = await prismaClient.fixedshift.findMany({
     select: {
       id: true,
       date: true,

--- a/server/repository/shiftRepository.ts
+++ b/server/repository/shiftRepository.ts
@@ -101,7 +101,7 @@ export const getShift = async (myId: string): Promise<ShiftModel[]> => {
 };
 
 export const getFixedShiftOnlyId = async (myId: string): Promise<ShiftModel[]> => {
-  const prismaTasks = await prismaClient.shift.findMany({
+  const prismaTasks = await prismaClient.fixedshift.findMany({
     where: { id: myId },
     select: {
       id: true,


### PR DESCRIPTION
<img width="960" alt="image" src="https://github.com/s1f102100793/shift-board/assets/85666759/6954cbeb-e240-4d7f-a60d-943f0489c55e">
<img width="960" alt="image" src="https://github.com/s1f102100793/shift-board/assets/85666759/040be1d0-b903-4ed9-8084-4db4ba85ccaa">
ユーザーの上から5人目のシフト状況が反映されています。
赤が編集して時間を変えたシフトで、それを上のユーザーのシフトを提出する画面で確認出来ます。