### PR TITLE
閉じるボタンと決まったシフト分をuseEffectで持ってくる所を変更

### DIFF
--- a/client/src/pages/calendar/ShiftBoard.module.css
+++ b/client/src/pages/calendar/ShiftBoard.module.css
@@ -226,7 +226,9 @@
 .closeButtonContainer {
   position: absolute; /* 絶対位置指定 */
   top: 10px; /* 上からの位置を指定 */
-  left: 10px; /* 左からの位置を指定 */
+  right: 10px; /* 左からの位置を指定 */
+  width: 80px;
+  height: 50px;
 }
 
 .autocompleteContainer > :first-child {

--- a/client/src/pages/calendar/index.page.tsx
+++ b/client/src/pages/calendar/index.page.tsx
@@ -190,7 +190,11 @@ const ShiftBoard: React.FC = () => {
     fetchShift();
     fetchFixedShift();
     const intervalId = setInterval(fetchShift, 100);
-    return () => clearInterval(intervalId);
+    const intervalNewId = setInterval(fetchFixedShift, 100);
+    return () => {
+      clearInterval(intervalId);
+      clearInterval(intervalNewId);
+    };
   }, [fetchShift, fetchFixedShift]);
 
   const handleDeleteShift = async () => {
@@ -274,7 +278,9 @@ const ShiftBoard: React.FC = () => {
         </button>
         <div className={`${styles.shiftBar} ${showShiftBar ? styles.shiftBarVisible : ''}`}>
           <div className={styles.closeButtonContainer}>
-            <button onClick={() => setShowShiftBar(false)}>閉じる</button>
+            <button className={styles.clearButton} onClick={() => setShowShiftBar(false)}>
+              閉じる
+            </button>
           </div>
           <div className="autocompleteContainer">
             <div className={styles.timespace}>


### PR DESCRIPTION
<img width="475" alt="image" src="https://github.com/s1f102100793/shift-board/assets/85666759/e8665e68-eb55-4b45-94c9-f2445e6ab515">
閉じるボタンが右にあった方が使い安いから右に変更し、
緑のマーク（確定したシフト）をuseEffectを使って、0.1秒ごとに持ってきて表示している