### PR TITLE
シフトを決める際に楽にシフトを決めれる

### DIFF
--- a/client/src/pages/employee/EmployeeTask.module.css
+++ b/client/src/pages/employee/EmployeeTask.module.css
@@ -86,3 +86,7 @@
 .redText {
   color: red;
 }
+
+.clickableRedText {
+  cursor: pointer;
+}

--- a/client/src/pages/employee/index.page.tsx
+++ b/client/src/pages/employee/index.page.tsx
@@ -35,7 +35,7 @@ const EmployeeTask = () => {
 
   const fetchShift = async () => {
     const fetchedShifts = await apiClient.shift.$get().catch(returnNull);
-    console.log(fetchedShifts);
+    // console.log(fetchedShifts);
     if (fetchedShifts !== null && fetchedShifts !== undefined) {
       setShifts(fetchedShifts);
       const uniqueEmployeeIds = [...new Set(fetchedShifts.map((shift) => shift.id))];
@@ -67,6 +67,7 @@ const EmployeeTask = () => {
   };
 
   const deleteFixedShift = async (employeeId: string, date: string) => {
+    // console.log(employeeId, date)
     await apiClient.fixedshift.delete({
       body: {
         id: employeeId,

--- a/client/src/pages/employee/index.page.tsx
+++ b/client/src/pages/employee/index.page.tsx
@@ -66,6 +66,15 @@ const EmployeeTask = () => {
     });
   };
 
+  const deleteFixedShift = async (employeeId: string, date: string) => {
+    await apiClient.fixedshift.delete({
+      body: {
+        id: employeeId,
+        date,
+      },
+    });
+  };
+
   useEffect(() => {
     const intervalId = setInterval(() => {
       fetchShift();
@@ -139,8 +148,15 @@ const EmployeeTask = () => {
                 if (fixedShiftForDay) {
                   displayShift = (
                     <span
-                      className={styles.redText}
-                    >{`${fixedShiftForDay.starttime} - ${fixedShiftForDay.endtime}`}</span>
+                      className={`${styles.redText} ${styles.clickableRedText}`}
+                      onClick={() => {
+                        if (window.confirm('この確定シフトを取り消しますか？')) {
+                          deleteFixedShift(employee, day.toString());
+                        }
+                      }}
+                    >
+                      {`${fixedShiftForDay.starttime} - ${fixedShiftForDay.endtime}`}
+                    </span>
                   );
                 } else if (shiftForDay) {
                   displayShift = (

--- a/client/src/pages/employee/index.page.tsx
+++ b/client/src/pages/employee/index.page.tsx
@@ -143,7 +143,21 @@ const EmployeeTask = () => {
                     >{`${fixedShiftForDay.starttime} - ${fixedShiftForDay.endtime}`}</span>
                   );
                 } else if (shiftForDay) {
-                  displayShift = `${shiftForDay.starttime} - ${shiftForDay.endtime}`;
+                  displayShift = (
+                    <span
+                      onClick={async () => {
+                        await createFixedShift(
+                          employee,
+                          day.toString(),
+                          shiftForDay.starttime,
+                          shiftForDay.endtime
+                        );
+                        // 必要に応じて、シフト情報の再取得やUIの更新を行う
+                      }}
+                    >
+                      {`${shiftForDay.starttime} - ${shiftForDay.endtime}`}
+                    </span>
+                  );
                 }
 
                 return <td key={day}>{displayShift}</td>;

--- a/client/src/pages/employee/index.page.tsx
+++ b/client/src/pages/employee/index.page.tsx
@@ -145,37 +145,32 @@ const EmployeeTask = () => {
                   (shift) => shift.id === employee && shift.date === day.toString()
                 );
 
-                let displayShift;
-                if (fixedShiftForDay) {
-                  displayShift = (
-                    <span
-                      className={`${styles.redText} ${styles.clickableRedText}`}
-                      onClick={() => {
-                        if (window.confirm('この確定シフトを取り消しますか？')) {
-                          deleteFixedShift(employee, day.toString());
-                        }
-                      }}
-                    >
-                      {`${fixedShiftForDay.starttime} - ${fixedShiftForDay.endtime}`}
-                    </span>
-                  );
-                } else if (shiftForDay) {
-                  displayShift = (
-                    <span
-                      onClick={async () => {
-                        await createFixedShift(
-                          employee,
-                          day.toString(),
-                          shiftForDay.starttime,
-                          shiftForDay.endtime
-                        );
-                        // 必要に応じて、シフト情報の再取得やUIの更新を行う
-                      }}
-                    >
-                      {`${shiftForDay.starttime} - ${shiftForDay.endtime}`}
-                    </span>
-                  );
-                }
+                const displayShift = fixedShiftForDay ? (
+                  <span
+                    className={`${styles.redText} ${styles.clickableRedText}`}
+                    onClick={() => {
+                      if (window.confirm('この確定シフトを取り消しますか？')) {
+                        deleteFixedShift(employee, day.toString());
+                      }
+                    }}
+                  >
+                    {`${fixedShiftForDay.starttime} - ${fixedShiftForDay.endtime}`}
+                  </span>
+                ) : shiftForDay ? (
+                  <span
+                    onClick={async () => {
+                      await createFixedShift(
+                        employee,
+                        day.toString(),
+                        shiftForDay.starttime,
+                        shiftForDay.endtime
+                      );
+                      // 必要に応じて、シフト情報の再取得やUIの更新を行う
+                    }}
+                  >
+                    {`${shiftForDay.starttime} - ${shiftForDay.endtime}`}
+                  </span>
+                ) : null;
 
                 return <td key={day}>{displayShift}</td>;
               })}

--- a/client/src/pages/employee/index.page.tsx
+++ b/client/src/pages/employee/index.page.tsx
@@ -1,3 +1,4 @@
+import type { HogeId } from 'commonTypesWithClient/branded';
 import type { ShiftModel } from 'commonTypesWithClient/models';
 import { useEffect, useState } from 'react';
 import { apiClient } from 'src/utils/apiClient';
@@ -58,7 +59,7 @@ const EmployeeTask = () => {
   ) => {
     await apiClient.fixedshift.post({
       body: {
-        id: employeeId,
+        id: employeeId as HogeId,
         date,
         starttime: newStartTime,
         endtime: newEndTime,
@@ -70,7 +71,7 @@ const EmployeeTask = () => {
     // console.log(employeeId, date)
     await apiClient.fixedshift.delete({
       body: {
-        id: employeeId,
+        id: employeeId as HogeId,
         date,
       },
     });

--- a/server/api/fixedshift/controller.ts
+++ b/server/api/fixedshift/controller.ts
@@ -1,4 +1,4 @@
-import { getFixedShift, shiftRepository2 } from '$/repository/shiftRepository';
+import { deleteFixedShift, getFixedShift, shiftRepository2 } from '$/repository/shiftRepository';
 import { defineController } from './$relay';
 
 export default defineController(() => ({
@@ -7,4 +7,8 @@ export default defineController(() => ({
     status: 201,
     body: await shiftRepository2.save(body.id, body.date, body.starttime, body.endtime),
   }),
+  delete: async ({ body }) => {
+    await deleteFixedShift(body.id, body.date);
+    return { status: 204 };
+  },
 }));

--- a/server/api/fixedshift/index.ts
+++ b/server/api/fixedshift/index.ts
@@ -1,3 +1,4 @@
+import type { HogeId } from '$/commonTypesWithClient/branded';
 import type { DefineMethods } from 'aspida';
 import type { ShiftModel } from '../../commonTypesWithClient/models';
 
@@ -7,7 +8,7 @@ export type Methods = DefineMethods<{
   };
   post: {
     reqBody: {
-      id: string;
+      id: HogeId;
       date: string;
       starttime: string;
       endtime: string;
@@ -15,7 +16,7 @@ export type Methods = DefineMethods<{
   };
   delete: {
     reqBody: {
-      id: string;
+      id: HogeId;
       date: string;
     };
   };

--- a/server/api/fixedshift/index.ts
+++ b/server/api/fixedshift/index.ts
@@ -13,4 +13,10 @@ export type Methods = DefineMethods<{
       endtime: string;
     };
   };
+  delete: {
+    reqBody: {
+      id: string;
+      date: string;
+    };
+  };
 }>;

--- a/server/api/fixedshift/index.ts
+++ b/server/api/fixedshift/index.ts
@@ -1,5 +1,5 @@
-import type { HogeId } from '$/commonTypesWithClient/branded';
 import type { DefineMethods } from 'aspida';
+import type { HogeId } from '../../commonTypesWithClient/branded';
 import type { ShiftModel } from '../../commonTypesWithClient/models';
 
 export type Methods = DefineMethods<{

--- a/server/commonTypesWithClient/branded.ts
+++ b/server/commonTypesWithClient/branded.ts
@@ -5,3 +5,5 @@ type Branded<T extends string> = string & z.BRAND<T>;
 export type UserId = Branded<'UserId'>;
 
 export type TaskId = Branded<'TaskId'>;
+
+export type HogeId = Branded<'HogeId'>;

--- a/server/repository/shiftRepository.ts
+++ b/server/repository/shiftRepository.ts
@@ -145,3 +145,9 @@ export const deleteShift = async (myId: string): Promise<void> => {
     where: { id: myId },
   });
 };
+
+export const deleteFixedShift = async (myId: string, date: string): Promise<void> => {
+  await prismaClient.shift.deleteMany({
+    where: { id: myId, date },
+  });
+};

--- a/server/repository/shiftRepository.ts
+++ b/server/repository/shiftRepository.ts
@@ -16,7 +16,6 @@ export const createShift = async (
   starttime: ShiftModel['starttime'],
   endtime: ShiftModel['endtime']
 ): Promise<ShiftModel> => {
-  console.log('来ている');
   const prismaShift = await prismaClient.shift.create({
     data: { id, date, starttime, endtime },
   });
@@ -38,11 +37,6 @@ export const createShift = async (
 
 export const shiftRepository = {
   save: async (id: string, date: string, starttime: string, endtime: string) => {
-    console.log('Upserting Shift with the following data:');
-    console.log(`ID: ${id}`);
-    console.log(`Date: ${date}`);
-    console.log(`Start Time: ${starttime}`);
-    console.log(`End Time: ${endtime}`);
     const res = await prismaClient.shift.upsert({
       where: { id_date: { id, date } },
       create: {
@@ -63,11 +57,6 @@ export const shiftRepository = {
 
 export const shiftRepository2 = {
   save: async (id: string, date: string, starttime: string, endtime: string) => {
-    console.log('Upserting Shift with the following data:');
-    console.log(`ID: ${id}`);
-    console.log(`Date: ${date}`);
-    console.log(`Start Time: ${starttime}`);
-    console.log(`End Time: ${endtime}`);
     const res = await prismaClient.fixedshift.upsert({
       where: { id_date: { id, date } },
       create: {
@@ -147,7 +136,6 @@ export const deleteShift = async (myId: string): Promise<void> => {
 };
 
 export const deleteFixedShift = async (myId: string, date: string): Promise<void> => {
-  console.log(myId, date);
   await prismaClient.fixedshift.deleteMany({
     where: { id: myId, date },
   });

--- a/server/repository/shiftRepository.ts
+++ b/server/repository/shiftRepository.ts
@@ -147,7 +147,8 @@ export const deleteShift = async (myId: string): Promise<void> => {
 };
 
 export const deleteFixedShift = async (myId: string, date: string): Promise<void> => {
-  await prismaClient.shift.deleteMany({
+  console.log(myId, date);
+  await prismaClient.fixedshift.deleteMany({
     where: { id: myId, date },
   });
 };


### PR DESCRIPTION
シフトを決める際に楽にシフトを決めれるようにstarttime-endtimeの部分をクリックするだけでデータベースに情報を送る

赤い文字の確定したシフトの部分を取り消すためのコードを書きました。

<img width="721" alt="image" src="https://github.com/s1f102100793/shift-board/assets/85666759/4dd68535-674e-427a-b64a-c1541553fe82">
